### PR TITLE
Fix paginate & staff users path

### DIFF
--- a/app/views/staff/users/show.html.erb
+++ b/app/views/staff/users/show.html.erb
@@ -13,7 +13,7 @@
 </div>
 
 <div class="text-center">
-  <%= link_to '/', class: 'btn btn-gray btn-md mb-5' do %>
+  <%= link_to staff_users_path, class: 'btn btn-gray btn-md mb-5' do %>
     <p>
       <i class="fas fa-backward"></i>
       <%= t("back")%>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -2,7 +2,7 @@
 Kaminari.configure do |config|
   # config.default_per_page = 25
   # config.max_per_page = nil
-  # config.window = 4
+  config.window = 2
   # config.outer_window = 0
   # config.left = 0
   # config.right = 0


### PR DESCRIPTION
修復頁尾的數字顯示，左右最多顯示2個
修復職員進入新增工讀生檢視學生資料時，回上一頁的路徑